### PR TITLE
feat: 엔티티 추가 및 수정

### DIFF
--- a/src/main/kotlin/com/haru/attendance/model/Attendance.kt
+++ b/src/main/kotlin/com/haru/attendance/model/Attendance.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 @Entity
 class Attendance(
     @Column(nullable = false)
-    val date: LocalDate = LocalDate.now(),
+    var date: LocalDate = LocalDate.now(),
     @Column(nullable = false)
     val clubId: Long,
 ) : BaseEntity()

--- a/src/main/kotlin/com/haru/attendance/model/AttendanceMember.kt
+++ b/src/main/kotlin/com/haru/attendance/model/AttendanceMember.kt
@@ -8,8 +8,8 @@ import java.time.LocalDateTime
 
 @Entity
 class AttendanceMember(
-    @Column(nullable = false)
-    val memberId: Long,
+    @ManyToOne(cascade = [CascadeType.ALL], optional = false)
+    val member: Member,
     @ManyToOne(cascade = [CascadeType.ALL], optional = false)
     val attendance: Attendance,
     @Column(nullable = false)

--- a/src/main/kotlin/com/haru/attendance/model/AttendanceMember.kt
+++ b/src/main/kotlin/com/haru/attendance/model/AttendanceMember.kt
@@ -13,7 +13,6 @@ class AttendanceMember(
     @ManyToOne(cascade = [CascadeType.ALL], optional = false)
     val attendance: Attendance,
     @Column(nullable = false)
-    val isAttended: Boolean,
-    @Column(nullable = false)
-    val attendedAt: LocalDateTime
+    var isAttended: Boolean = false,
+    val attendedAt: LocalDateTime? = null
 ) : BaseEntity()

--- a/src/main/kotlin/com/haru/attendance/model/AttendanceMember.kt
+++ b/src/main/kotlin/com/haru/attendance/model/AttendanceMember.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.ManyToOne
+import java.time.LocalDateTime
 
 @Entity
 class AttendanceMember(
@@ -13,4 +14,6 @@ class AttendanceMember(
     val attendance: Attendance,
     @Column(nullable = false)
     val isAttended: Boolean,
+    @Column(nullable = false)
+    val attendedAt: LocalDateTime
 ) : BaseEntity()

--- a/src/main/kotlin/com/haru/attendance/model/Club.kt
+++ b/src/main/kotlin/com/haru/attendance/model/Club.kt
@@ -5,12 +5,25 @@ import jakarta.persistence.Entity
 
 @Entity
 class Club(
-    @Column(nullable = false, length = 30)
-    var name: String,
+    name: String
 ) : BaseEntity() {
+    @Column(nullable = false)
+    var name: String
+        private set
+
     init {
+        validateName(name)
+        this.name = name
+    }
+
+    private fun validateName(name: String) {
         if (name.length > 30) {
             throw IllegalArgumentException("그룹의 이름은 30자를 넘기면 안된다")
         }
+    }
+
+    fun updateName(name: String) {
+        validateName(name)
+        this.name = name
     }
 }

--- a/src/main/kotlin/com/haru/attendance/model/ClubUser.kt
+++ b/src/main/kotlin/com/haru/attendance/model/ClubUser.kt
@@ -12,5 +12,5 @@ class ClubUser(
     @Column(nullable = false)
     val userId: Long,
     @Enumerated(EnumType.STRING)
-    val role: Role
+    var role: Role
 ) : BaseEntity()

--- a/src/main/kotlin/com/haru/attendance/model/ClubUser.kt
+++ b/src/main/kotlin/com/haru/attendance/model/ClubUser.kt
@@ -1,0 +1,16 @@
+package com.haru.attendance.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+
+@Entity
+class ClubUser(
+    @Column(nullable = false)
+    val clubId: Long,
+    @Column(nullable = false)
+    val userId: Long,
+    @Enumerated(EnumType.STRING)
+    val role: Role
+) : BaseEntity()

--- a/src/main/kotlin/com/haru/attendance/model/ClubUserMember.kt
+++ b/src/main/kotlin/com/haru/attendance/model/ClubUserMember.kt
@@ -1,0 +1,12 @@
+package com.haru.attendance.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+
+@Entity
+class ClubUserMember(
+    @Column(nullable = false)
+    val clubUserId: Long,
+    @Column(nullable = false)
+    val memberId: Long
+) : BaseEntity()

--- a/src/main/kotlin/com/haru/attendance/model/Member.kt
+++ b/src/main/kotlin/com/haru/attendance/model/Member.kt
@@ -8,8 +8,28 @@ import jakarta.persistence.ManyToOne
 class Member(
     @Column(nullable = false)
     val clubId: Long,
-    @Column(nullable = false)
-    var name: String,
+    name: String,
     @ManyToOne(optional = false)
     var unit: Unit
-) : BaseEntity()
+) : BaseEntity() {
+    @Column(nullable = false)
+    var name: String
+        private set
+
+    init {
+        validateMemberName(name)
+        this.name = name
+    }
+
+    private fun validateMemberName(name: String) {
+        if (name.length > 30) {
+            throw IllegalArgumentException("멤버의 이름은 30자를 넘기면 안된다")
+        }
+    }
+
+    fun updateName(name: String) {
+        validateMemberName(name)
+        this.name = name
+    }
+}
+

--- a/src/main/kotlin/com/haru/attendance/model/Member.kt
+++ b/src/main/kotlin/com/haru/attendance/model/Member.kt
@@ -2,16 +2,14 @@ package com.haru.attendance.model
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.ManyToOne
 
 @Entity
 class Member(
-    var userId: Long?,
     @Column(nullable = false)
     val clubId: Long,
     @Column(nullable = false)
-    var unitId: Long,
-    @Column(nullable = false)
     var name: String,
-    @Column(nullable = false)
-    var role: Role
+    @ManyToOne(optional = false)
+    var unit: Unit
 ) : BaseEntity()

--- a/src/main/kotlin/com/haru/attendance/model/Role.kt
+++ b/src/main/kotlin/com/haru/attendance/model/Role.kt
@@ -2,5 +2,5 @@ package com.haru.attendance.model
 
 enum class Role {
     ADMINISTRATOR,
-    NORMAL_MEMBER
+    Member
 }

--- a/src/main/kotlin/com/haru/attendance/model/Role.kt
+++ b/src/main/kotlin/com/haru/attendance/model/Role.kt
@@ -2,5 +2,5 @@ package com.haru.attendance.model
 
 enum class Role {
     ADMINISTRATOR,
-    Member
+    MEMBER
 }

--- a/src/main/kotlin/com/haru/attendance/model/Unit.kt
+++ b/src/main/kotlin/com/haru/attendance/model/Unit.kt
@@ -5,8 +5,42 @@ import jakarta.persistence.Entity
 
 @Entity
 class Unit(
-    @Column(nullable = false)
-    var name: String,
+    name: String,
     @Column(nullable = false)
     val clubId: Long
-) : BaseEntity()
+) : BaseEntity() {
+    @Column(nullable = false)
+    var name: String
+        private set
+
+    init {
+        validateUnitName(name)
+        this.name = name
+    }
+
+    private fun validateUnitName(name: String) {
+        if (name.length > 10) {
+            throw IllegalArgumentException("유닛의 이름은 10자를 넘기면 안된다")
+        }
+    }
+
+//    override fun equals(other: Any?): Boolean {
+//        if (this === other) return true
+//        if (javaClass != other?.javaClass) return false
+//        if (!super.equals(other)) return false
+//
+//        other as Unit
+//
+//        if (name != other.name) return false
+//        if (clubId != other.clubId) return false
+//
+//        return true
+//    }
+//
+//    override fun hashCode(): Int {
+//        var result = super.hashCode()
+//        result = 31 * result + name.hashCode()
+//        result = 31 * result + clubId.hashCode()
+//        return result
+//    }
+}

--- a/src/main/kotlin/com/haru/attendance/model/Unit.kt
+++ b/src/main/kotlin/com/haru/attendance/model/Unit.kt
@@ -1,0 +1,12 @@
+package com.haru.attendance.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+
+@Entity
+class Unit(
+    @Column(nullable = false)
+    var name: String,
+    @Column(nullable = false)
+    val clubId: Long
+) : BaseEntity()

--- a/src/test/kotlin/com/haru/attendance/model/ClubTest.kt
+++ b/src/test/kotlin/com/haru/attendance/model/ClubTest.kt
@@ -2,16 +2,33 @@ package com.haru.attendance.model
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 
 class ClubTest : BehaviorSpec({
     given("이전에 그룹이 없을때 ") {
         `when`("그룹을 생성할 경우") {
             then("이름과 함께 그룹을 생성할 수 있다.") {
-                Club("그룹명")
+                val club = Club("그룹명")
+                club.name shouldBe "그룹명"
             }
             then("그룹의 이름은 30자를 넘기면 예외를 발생한다.") {
                 shouldThrow<IllegalArgumentException> {
                     Club("12345678901234567890121234567890123456789012")
+                }
+            }
+        }
+    }
+    given("이전에 그룹이 있을때") {
+        `when`("그룹의 이름을 수정할 경우") {
+            then("그룹의 이름을 수정할 수 있다.") {
+                val club = Club("그룹명")
+                club.updateName("그룹명2")
+                club.name shouldBe "그룹명2"
+            }
+            then("그룹의 이름은 30자를 넘기면 예외를 발생한다.") {
+                val club = Club("그룹명")
+                shouldThrow<IllegalArgumentException> {
+                    club.updateName("12345678901234567890121234567890123456789012")
                 }
             }
         }

--- a/src/test/kotlin/com/haru/attendance/model/ClubTest.kt
+++ b/src/test/kotlin/com/haru/attendance/model/ClubTest.kt
@@ -3,7 +3,7 @@ package com.haru.attendance.model
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 
-class GroupTest : BehaviorSpec({
+class ClubTest : BehaviorSpec({
     given("이전에 그룹이 없을때 ") {
         `when`("그룹을 생성할 경우") {
             then("이름과 함께 그룹을 생성할 수 있다.") {

--- a/src/test/kotlin/com/haru/attendance/model/MemberTest.kt
+++ b/src/test/kotlin/com/haru/attendance/model/MemberTest.kt
@@ -1,0 +1,44 @@
+package com.haru.attendance.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class MemberTest : BehaviorSpec(
+    {
+        given("이전에 멤버가 없을 경우") {
+            `when`("멤버를 생성할 때") {
+                then("clubId, unit, 멤버 이름으로 멤버를 생성한다.") {
+                    val unit = Unit("테스트", 1)
+                    val member = Member(1, "echo", unit)
+                    member.clubId shouldBe 1
+                    member.unit shouldBe unit
+                    member.name shouldBe "echo"
+                }
+                then("멤버의 이름은 30자를 넘기면 예외를 발생한다.") {
+                    val unit = Unit("테스트", 1)
+                    shouldThrow<IllegalArgumentException> {
+                        Member(1, "12345678901234567890121234567890123456789012", unit)
+                    }
+                }
+            }
+        }
+        given("이전에 멤버가 있을 경우") {
+            `when`("멤버의 이름을 수정할 때") {
+                then("멤버의 이름을 수정할 수 있다.") {
+                    val unit = Unit("테스트", 1)
+                    val member = Member(1, "echo", unit)
+                    member.updateName("echo2")
+                    member.name shouldBe "echo2"
+                }
+                then("멤버의 이름은 30자를 넘기면 예외를 발생한다.") {
+                    val unit = Unit("테스트", 1)
+                    val member = Member(1, "echo", unit)
+                    shouldThrow<IllegalArgumentException> {
+                        member.updateName("12345678901234567890121234567890123456789012")
+                    }
+                }
+            }
+        }
+    }
+)

--- a/src/test/kotlin/com/haru/attendance/model/UnitTest.kt
+++ b/src/test/kotlin/com/haru/attendance/model/UnitTest.kt
@@ -1,0 +1,31 @@
+package com.haru.attendance.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class UnitTest : BehaviorSpec({
+    given("이전에 유닛이 없을 경우") {
+        `when`("유닛을 생성할 때") {
+            then("유닛 이름과 클럽 아이디로 유닛을 생성한다.") {
+                val unit = Unit("테스트", 1)
+                unit.clubId shouldBe 1
+                unit.name shouldBe "테스트"
+            }
+            then("유닛의 이름은 10자를 넘기면 예외를 발생한다.") {
+                shouldThrow<IllegalArgumentException> {
+                    Unit("12345678901", 1)
+                }
+            }
+        }
+    }
+    given("유닛") {
+        `when`("같은 이름과 clubId를 가진 유닛은") {
+            then("같은 유닛이다") {
+                val unit1 = Unit("테스트", 1)
+                val unit2 = Unit("테스트", 1)
+                unit1 shouldBe unit2
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/haru/attendance/model/UserTest.kt
+++ b/src/test/kotlin/com/haru/attendance/model/UserTest.kt
@@ -1,32 +1,36 @@
 package com.haru.attendance.model
 
+import io.kotest.core.spec.style.BehaviorSpec
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertAll
-import org.junit.jupiter.api.Test
 
-class UserTest {
+class UserTest : BehaviorSpec(
+    {
+        given("User를 생성할 때") {
+            `when`("기본 생성자로 생성할 경우") {
+                then("id는 0이고, name과 username은 빈 문자열이다.") {
+                    val user = User()
 
-    @Test
-    fun 기본_생성자로_User를_생성할_수_있다() {
-        val user = User()
+                    assertAll(
+                        { Assertions.assertThat(user.id).isEqualTo(0L) },
+                        { Assertions.assertThat(user.name).isEqualTo("") },
+                        { Assertions.assertThat(user.username).isEqualTo("") }
+                    )
+                }
+            }
+            `when`("인자를 전달받는 생성자로 생성할 경우") {
+                then("id는 0이고, name과 username은 전달받은 값이다.") {
+                    val user = User("hanbin", "konghana", "123")
 
-        assertAll(
-            { Assertions.assertThat(user.id).isEqualTo(0L) },
-            { Assertions.assertThat(user.name).isEqualTo("") },
-            { Assertions.assertThat(user.username).isEqualTo("") }
-        )
+                    assertAll(
+                        { Assertions.assertThat(user.id).isEqualTo(0L) },
+                        { Assertions.assertThat(user.name).isEqualTo("hanbin") },
+                        { Assertions.assertThat(user.username).isEqualTo("konghana") }
+                    )
+                }
+            }
+        }
     }
-
-    @Test
-    fun 인자를_전달받는_생성자로_User를_생성할_수_있다() {
-        val user = User("hanbin", "konghana", "123")
-
-        assertAll(
-            { Assertions.assertThat(user.id).isEqualTo(0L) },
-            { Assertions.assertThat(user.name).isEqualTo("hanbin") },
-            { Assertions.assertThat(user.username).isEqualTo("konghana") }
-        )
-    }
-}
+)
 
 

--- a/src/test/kotlin/com/haru/attendance/model/UserTest.kt
+++ b/src/test/kotlin/com/haru/attendance/model/UserTest.kt
@@ -1,8 +1,7 @@
 package com.haru.attendance.model
 
 import io.kotest.core.spec.style.BehaviorSpec
-import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.Assertions.assertAll
+import io.kotest.matchers.shouldBe
 
 class UserTest : BehaviorSpec(
     {
@@ -10,23 +9,17 @@ class UserTest : BehaviorSpec(
             `when`("기본 생성자로 생성할 경우") {
                 then("id는 0이고, name과 username은 빈 문자열이다.") {
                     val user = User()
-
-                    assertAll(
-                        { Assertions.assertThat(user.id).isEqualTo(0L) },
-                        { Assertions.assertThat(user.name).isEqualTo("") },
-                        { Assertions.assertThat(user.username).isEqualTo("") }
-                    )
+                    user.id shouldBe 0L
+                    user.name shouldBe ""
+                    user.username shouldBe ""
                 }
             }
             `when`("인자를 전달받는 생성자로 생성할 경우") {
                 then("id는 0이고, name과 username은 전달받은 값이다.") {
                     val user = User("hanbin", "konghana", "123")
-
-                    assertAll(
-                        { Assertions.assertThat(user.id).isEqualTo(0L) },
-                        { Assertions.assertThat(user.name).isEqualTo("hanbin") },
-                        { Assertions.assertThat(user.username).isEqualTo("konghana") }
-                    )
+                    user.id shouldBe 0L
+                    user.name shouldBe "hanbin"
+                    user.username shouldBe "konghana"
                 }
             }
         }


### PR DESCRIPTION
### 관련 이슈
resolved: #14 

### 노트
- MemberProperty는 아직 추가 안함
- AttendanceMember의 경우 memberId → Member로 수정했는데, 이유는 AttendanceMember를 조회할 경우 Member 정보가 추가로 필요하기 때문
- 이름이 들어간 엔티티들의 경우 이름 검증 로직 추가